### PR TITLE
Moves fsevents to optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "eslint-plugin-jest": "^22.19.0",
-    "fsevents": "^1.2.9",
     "prop-types": "^15.7.2",
     "react": "16.8.3",
     "react-art": "^16.10.2",
@@ -40,5 +39,8 @@
     "metro-react-native-babel-preset": "^0.53.1",
     "react-devtools": "^3.6.3",
     "react-test-renderer": "16.8.3"
+  },
+  "optionalDependencies": {
+    "fsevents": "^1.2.9"
   }
 }


### PR DESCRIPTION
I was unable to install dependencies for this project on Linux due to `fsevents` which only works on MacOS

I've moved `fsevents` to `optionalDependencies` in `package.json`, which now allows for it to be skipped during install on Linux